### PR TITLE
Feat/create delivery product

### DIFF
--- a/app/domain/dto/delivery.go
+++ b/app/domain/dto/delivery.go
@@ -4,6 +4,6 @@ type Delivery struct {
 	Reference  string
 	Qty        int32
 	ClientID   int32
-	MedicineID int32
 	UnitID     int32
+	ProductIDs []int
 }

--- a/app/domain/entity/delivery.go
+++ b/app/domain/entity/delivery.go
@@ -5,13 +5,12 @@ import (
 )
 
 type Delivery struct {
-	ID         uint
-	Reference  string
-	ClientID   uint
-	MedicineID uint
-	Qty        int32
-	TypeID     uint
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	DeletedAt  *time.Time
+	ID        uint
+	Reference string
+	ClientID  uint
+	Qty       int32
+	TypeID    uint
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
 }

--- a/app/gateway/api/handler/delivery_handler.go
+++ b/app/gateway/api/handler/delivery_handler.go
@@ -124,7 +124,6 @@ func (h *Handler) CreateDelivery() http.HandlerFunc {
 		data, err := h.useCase.CreateDelivery(req.Context(), useCaseInput)
 		if err != nil {
 			resp := response.InternalServerError(err)
-			print(err.Error())
 			rest.SendJSON(rw, resp.Status, resp.Payload, resp.Headers) //nolint:errcheck
 
 			return

--- a/app/gateway/api/handler/delivery_handler.go
+++ b/app/gateway/api/handler/delivery_handler.go
@@ -95,9 +95,9 @@ func (h *Handler) CreateDelivery() http.HandlerFunc {
 
 		useCaseInput := usecase.CreateDeliveryInput{}
 		useCaseInput.Delivery.Qty = deliveryBody.Qty
-		useCaseInput.Delivery.MedicineID = deliveryBody.MedicineID
 		useCaseInput.Delivery.UnitID = deliveryBody.UnitID
 		useCaseInput.Delivery.ClientID = deliveryBody.ClientID
+		useCaseInput.Delivery.ProductIDs = deliveryBody.ProductIDs
 
 		var reference string
 
@@ -124,6 +124,7 @@ func (h *Handler) CreateDelivery() http.HandlerFunc {
 		data, err := h.useCase.CreateDelivery(req.Context(), useCaseInput)
 		if err != nil {
 			resp := response.InternalServerError(err)
+			print(err.Error())
 			rest.SendJSON(rw, resp.Status, resp.Payload, resp.Headers) //nolint:errcheck
 
 			return

--- a/app/gateway/api/handler/schema/delivery.go
+++ b/app/gateway/api/handler/schema/delivery.go
@@ -30,8 +30,8 @@ type CreateDeliveryResponse struct {
 type CreateDeliveryRequest struct {
 	Qty        int32 `json:"qty"`
 	ClientID   int32 `json:"client_id"`
-	MedicineID int32 `json:"medicine_id"`
 	UnitID     int32 `json:"unit_id"`
+	ProductIDs []int `json:"product_ids"`
 }
 
 type DeliveryResponse struct {
@@ -60,12 +60,12 @@ func ValidateCreateDeliveryRequest(input *CreateDeliveryRequest) error {
 		return errors.New("client_id must be provided")
 	}
 
-	if input.MedicineID == 0 {
-		return errors.New("medicine_id must be provided")
-	}
-
 	if input.UnitID == 0 {
 		return errors.New("unit_id must be provided")
+	}
+
+	if len(input.ProductIDs) == 0 {
+		return errors.New("product_ids must be provided")
 	}
 
 	return nil

--- a/app/gateway/postgres/migrations/000003_add_deliveries.down.sql
+++ b/app/gateway/postgres/migrations/000003_add_deliveries.down.sql
@@ -1,3 +1,3 @@
 BEGIN;
-DROP TABLE IF EXISTS delivery;
+DROP TABLE IF EXISTS deliveries;
 COMMIT;

--- a/app/gateway/postgres/migrations/000005_add_delivery_product.down.sql
+++ b/app/gateway/postgres/migrations/000005_add_delivery_product.down.sql
@@ -1,0 +1,5 @@
+begin;
+
+drop table if exists delivery_product cascade;
+
+commit;

--- a/app/gateway/postgres/migrations/000005_add_delivery_product.up.sql
+++ b/app/gateway/postgres/migrations/000005_add_delivery_product.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+CREATE TABLE IF NOT EXISTS delivery_product (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    delivery_id BIGINT NOT NULL,
+    product_id BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ,
+
+    FOREIGN KEY (delivery_id) REFERENCES deliveries (id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE
+);
+COMMIT;

--- a/app/gateway/postgres/migrations/000006_remove_medicine_id.down.sql
+++ b/app/gateway/postgres/migrations/000006_remove_medicine_id.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE deliveries ADD COLUMN medicine_id BIGINT NOT NULL;
+COMMIT;

--- a/app/gateway/postgres/migrations/000006_remove_medicine_id.up.sql
+++ b/app/gateway/postgres/migrations/000006_remove_medicine_id.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE deliveries DROP COLUMN medicine_id;
+COMMIT;

--- a/app/gateway/postgres/repositories/deliveries_create.go
+++ b/app/gateway/postgres/repositories/deliveries_create.go
@@ -17,7 +17,12 @@ func (r *DeliveriesRepository) Create(ctx context.Context, input usecase.CreateD
 	if err != nil {
 		return entity.Delivery{}, fmt.Errorf("%s: %w", operation, err)
 	}
-	defer tx.Rollback(ctx)
+
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && err == nil {
+			err = rollbackErr
+		}
+	}()
 
 	query := `
 		INSERT INTO deliveries (reference, client_id, qty, unit_id)


### PR DESCRIPTION
- Criada tabela de `delivery_product` para manter as relações de delivery com products
- Removido parâmetro de `medicine_id`, visto que agora serão passados os ids dos produtos
- Adicionado parâmetro de `product_ids`, que é um slice de ids de produtos que serão entregados
- Feita a inserção da delivery junto com os delivery_products com transaction no banco, inserindo uma linha em `delivery_product` para cada id de produto 
- Mantido o retorno original da chamada