### PR TITLE
chore: make docker manage the database volume and add a way of clean …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ start:
 	docker compose -f $(DOCKER_COMPOSE_FILE_LOCAL) -p $(PROJECT) down --remove-orphans
 	docker compose -f $(DOCKER_COMPOSE_FILE_LOCAL) -p $(PROJECT) up --remove-orphans
 
+clean:
+	docker compose -f $(DOCKER_COMPOSE_FILE_LOCAL) -p $(PROJECT) down --volumes --remove-orphans
+
 mock:
 
 lint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
-version: '3'
 services:
   postgresdb:
     image: "postgres"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: farmacia-tech-db
+      POSTGRES_USER:  "${DB_USER}"
+      POSTGRES_PASSWORD:  "${DB_PASSWORD}"
+      POSTGRES_DB: "${DB_NAME}"
     ports:
-      - "5432:5432"
+      - "${DB_PORT}:5432"
     volumes:
-      - ../postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
Percebi que o Makefile não estava deletando o volume com o docker compose down pela falta da flag --volumes. Além disso o volume do banco de dados estava sendo criado no ambiente do host, fora do gerenciamento do docker.  Adicionei uma task no Makefile (clean) para deletar os volumes e passei seu gerenciamento para docker.

Além disso, mudei as variáveis de ambiente no arquivo docker-compose.yml para usar os dados do arquivo .env. Na minha opinião ficou um pouco mais automatizado, mas se essa não for a intenção pode fechar o pr.